### PR TITLE
Removed default value to resolve php 8.0 deprecation error

### DIFF
--- a/src/Routing/PurlRouteProvider.php
+++ b/src/Routing/PurlRouteProvider.php
@@ -118,8 +118,8 @@ class PurlRouteProvider extends RouteProvider {
     CacheBackendInterface $cache_backend,
     InboundPathProcessorInterface $path_processor,
     CacheTagsInvalidatorInterface $cache_tag_invalidator,
-    $table = 'router',
-    LanguageManagerInterface $language_manager = NULL,
+    $table,
+    LanguageManagerInterface $language_manager,
     ContextHelper $contextHelper,
     MatchedModifiers $matchedModifiers
   ) {


### PR DESCRIPTION
While updating the PHP version from 7.3 to 8.0 below errors were generated.

```
PHP Deprecated: Required parameter $contextHelper follows optional parameter $table in /var/www/html/web/modules/contrib/purl/src/Routing/PurlRouteProvider.php on line 114
Deprecated: Required parameter $contextHelper follows optional parameter $table in /var/www/html/web/modules/contrib/purl/src/Routing/PurlRouteProvider.php on line 114
PHP Deprecated: Required parameter $matchedModifiers follows optional parameter $table in /var/www/html/web/modules/contrib/purl/src/Routing/PurlRouteProvider.php on line 114
Deprecated: Required parameter $matchedModifiers follows optional parameter $table in /var/www/html/web/modules/contrib/purl/src/Routing/PurlRouteProvider.php on line 114

```

Raised PR to resolve the above warnings.
